### PR TITLE
Make after() return Timer obj for fluent interface

### DIFF
--- a/Timer.js
+++ b/Timer.js
@@ -141,6 +141,7 @@
             Timer.prototype.unbind.call(self, fn);
             callback.apply(this, arguments);
         });
+        return this;
     };
 
     return Timer;


### PR DESCRIPTION
return `this` from `after()` to allow fluent usage like `Timer().after('5s', function() { alert('Moo')}).start();`.  
