### PR TITLE
Add a drift() method that will add a given number of milliseconds to the next event call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ automatically after the event is fired:
 
 `timer.running()` indicates if the timer is running.
 
+`timer.drift(driftAmount)` Adds `driftAmount` milliseconds to the next event call. This should allow rudimentary syncing between different clocks.
+
 ### Usage example
 
     var timer = new Timer('100 milliseconds');

--- a/Timer.js
+++ b/Timer.js
@@ -62,6 +62,7 @@
         this._running = false;
         this._ticks = 0;
         this._timer = null;
+        this._drift = 0;
     }
 
     Timer.prototype = {
@@ -77,7 +78,8 @@
                         }
                     }
                     if (self._running) {
-                        self._timer = setTimeout(loopsyloop, self._resolution);
+                        self._timer = setTimeout(loopsyloop, self._resolution + self._drift);
+                        self._drift = 0;
                     }
                 }, this._resolution);
             }
@@ -130,8 +132,10 @@
                 }
             }
             return this;
+        },
+        drift: function (timeDrift) {
+            this._drift = timeDrift;
         }
-
     };
 
     Timer.prototype.every = Timer.prototype.bind;

--- a/test/blah.js
+++ b/test/blah.js
@@ -1,0 +1,9 @@
+var Timer = require('../timer.js');
+
+var timer = new Timer(100);
+
+timer.every(100, function(){
+  console.log(timer.ticks());
+});
+
+timer.start();

--- a/test/blah.js
+++ b/test/blah.js
@@ -1,9 +1,0 @@
-var Timer = require('../timer.js');
-
-var timer = new Timer(100);
-
-timer.every(100, function(){
-  console.log(timer.ticks());
-});
-
-timer.start();

--- a/test/time-drift.js
+++ b/test/time-drift.js
@@ -1,0 +1,40 @@
+
+var chai = require('chai');
+chai.should();
+
+var Timer = require('../timer.js');
+
+describe('Timer', function() {
+  var tickResolution = 1000;
+  var timer = new Timer(tickResolution);
+  var driftAmount = 1000;
+
+  describe('given ' + driftAmount + 'ms drift', function() {
+    it('should fire the next tick an extra ' + driftAmount + 'ms after the previous tick', function(done) {
+      var lastTime = getUsefulTime(tickResolution);
+      var ticksToRun = 2;
+
+      timer.every(tickResolution, function() {
+        if (timer.ticks() == ticksToRun) {
+          timer.drift(driftAmount);
+        }
+        if (timer.ticks() > ticksToRun) {
+          var endTime = getUsefulTime(tickResolution);
+          
+          // Divide millisecond amounts by the resolution so we don't miss our test because the resolution was too high for the clock
+          endTime.should.equal(lastTime + (tickResolution / tickResolution) + Math.floor(driftAmount / tickResolution));
+          done();
+        }
+
+        lastTime = getUsefulTime(tickResolution);
+      });
+
+      timer.start();
+    });
+  });
+});
+
+function getUsefulTime(resolution) {
+  var usefulTime = Math.floor((new Date()).getTime() / resolution);
+  return usefulTime;
+};


### PR DESCRIPTION
The idea is to allow some simple syncing between different clocks. If we know the time drift between two clocks in milliseconds, then we can use `timer.drift()` to add or subtract that number from when the next event will run.

I've added a test demonstrating this. You can run it with `mocha --timeout 5000 test`. I also added documentation of the `drift()` method to the readme.

_Note: I didn't add `test` to the scripts part of package.json. nor did I add any devDependencies for chai or mocha._
