### PR TITLE
minor fix: missing assignment of setTimeout "id"

### DIFF
--- a/Timer.js
+++ b/Timer.js
@@ -70,7 +70,7 @@
             var self = this;
             if (!this._running) {
                 this._running = !this._running;
-                setTimeout(function loopsyloop() {
+                this._timer = setTimeout(function loopsyloop() {
                     self._ticks++;
                     for (var i = 0, l = self._notifications.length; i < l; i++) {
                         if (self._notifications[i] && self._ticks % self._notifications[i].ticks === 0) {


### PR DESCRIPTION
This was causing a bug if you stopped and started the timer "frequently" before the first timeout was resolved, like on:

```js
document.addEventListener('mousemove', on_mousemove);
function on_mousemove() {
    timer.stop().start(); // restarting the timer on mouse move
}
```

